### PR TITLE
Added "sinc" effect, and a "custom" argument

### DIFF
--- a/pysndfx/dsp.py
+++ b/pysndfx/dsp.py
@@ -134,6 +134,7 @@ class AudioEffectsChain:
         if right_n is not None:
             self.command.append("-n")
             self.command.append(str(right_n))
+        return self
 
     def bend(self, bends, frame_rate=None, over_sample=None):
         self.command.append("bend")

--- a/pysndfx/dsp.py
+++ b/pysndfx/dsp.py
@@ -16,8 +16,7 @@ from pysndfx.sndfiles import FilePathInput, FileBufferInput, NumpyArrayInput, Fi
 
 
 def mutually_exclusive(*args):
-    are_none = map(lambda x: x is not None, args)
-    return sum(are_none) in [0, 1]
+    return sum(arg is not None for arg in args) < 2
 
 
 class AudioEffectsChain:
@@ -84,14 +83,14 @@ class AudioEffectsChain:
         raise NotImplemented()
         return self
 
-    def sinc(self, hpfreq=None, lpfreq=None,
+    def sinc(self, high_pass_frequency=None, low_pass_frequency=None,
              left_t=None, left_n=None,
              right_t=None, right_n=None,
              attenuation=None, beta=None,
              phase=None, M=None, I=None, L=None):
         self.command.append("sinc")
         if not mutually_exclusive(attenuation, beta):
-            raise RuntimeError("Attenuation (-a) and beta (-b) are mutually exclusive arguments")
+            raise ValueError("Attenuation (-a) and beta (-b) are mutually exclusive arguments")
         if attenuation is not None and beta is None:
             self.command.append("-a")
             self.command.append(str(attenuation))
@@ -100,7 +99,7 @@ class AudioEffectsChain:
             self.command.append(str(beta))
 
         if not mutually_exclusive(phase, M, I, L):
-            raise RuntimeError("Phase (-p), -M, L, and -I are mutually exclusive arguments")
+            raise ValueError("Phase (-p), -M, L, and -I are mutually exclusive arguments")
         if phase is not None:
             self.command.append("-p")
             self.command.append(str(phase))
@@ -112,7 +111,7 @@ class AudioEffectsChain:
             self.command.append("-L")
 
         if not mutually_exclusive(left_t, left_t):
-            raise RuntimeError("Transition bands options (-t or -n) are mutually exclusive")
+            raise ValueError("Transition bands options (-t or -n) are mutually exclusive")
         if left_t is not None:
             self.command.append("-t")
             self.command.append(str(left_t))
@@ -120,15 +119,15 @@ class AudioEffectsChain:
             self.command.append("-n")
             self.command.append(str(left_n))
         
-        if hpfreq is not None and lpfreq is None:
-            self.command.append(str(hpfreq))
-        elif hpfreq is not None and lpfreq is not None:
-            self.command.append(str(hpfreq)+ "-" + str(lpfreq))
-        elif hpfreq is None and lpfreq is not None:
-            self.command.append(str(lpfreq))
+        if high_pass_frequency is not None and low_pass_frequency is None:
+            self.command.append(str(high_pass_frequency))
+        elif high_pass_frequency is not None and low_pass_frequency is not None:
+            self.command.append(str(high_pass_frequency) + "-" + str(low_pass_frequency))
+        elif high_pass_frequency is None and low_pass_frequency is not None:
+            self.command.append(str(low_pass_frequency))
 
         if not mutually_exclusive(right_t, right_t):
-            raise RuntimeError("Transition bands options (-t or -n) are mutually exclusive")
+            raise ValueError("Transition bands options (-t or -n) are mutually exclusive")
         if right_t is not None:
             self.command.append("-t")
             self.command.append(str(right_t))
@@ -338,6 +337,8 @@ class AudioEffectsChain:
         return self
 
     def custom(self, command_str):
+        """Example value for command_str : 'echo 0.8 0.9 1000 0.3'
+        for an echo effect"""
         self.command.append(command_str)
         return self
 

--- a/pysndfx/dsp.py
+++ b/pysndfx/dsp.py
@@ -336,6 +336,10 @@ class AudioEffectsChain:
             self.command.append(str(limiter_gain))
         return self
 
+    def custom(self, command_str):
+        self.command.append(command_str)
+        return self
+
     def __call__(self,
                  src,
                  dst=np.ndarray,

--- a/pysndfx/dsp.py
+++ b/pysndfx/dsp.py
@@ -89,6 +89,7 @@ class AudioEffectsChain:
              right_t=None, right_n=None,
              attenuation=None, beta=None,
              phase=None, M=None, I=None, L=None):
+        self.command.append("sinc")
         if not mutually_exclusive(attenuation, beta):
             raise RuntimeError("Attenuation (-a) and beta (-b) are mutually exclusive arguments")
         if attenuation is not None and beta is None:

--- a/pysndfx/dsp.py
+++ b/pysndfx/dsp.py
@@ -15,8 +15,9 @@ from pysndfx.sndfiles import FilePathInput, FileBufferInput, NumpyArrayInput, Fi
     FileBufferOutput
 
 
-class InvalidEffectParameter(Exception):
-    pass
+def mutually_exclusive(*args):
+    are_none = map(lambda x: x is not None, args)
+    return sum(are_none) in [0, 1]
 
 
 class AudioEffectsChain:
@@ -82,6 +83,57 @@ class AudioEffectsChain:
     def compand(self, attack=0.05, decay=0.5):
         raise NotImplemented()
         return self
+
+    def sinc(self, hpfreq=None, lpfreq=None,
+             left_t=None, left_n=None,
+             right_t=None, right_n=None,
+             attenuation=None, beta=None,
+             phase=None, M=None, I=None, L=None):
+        if not mutually_exclusive(attenuation, beta):
+            raise RuntimeError("Attenuation (-a) and beta (-b) are mutually exclusive arguments")
+        if attenuation is not None and beta is None:
+            self.command.append("-a")
+            self.command.append(str(attenuation))
+        elif attenuation is None and beta is not None:
+            self.command.append("-b")
+            self.command.append(str(beta))
+
+        if not mutually_exclusive(phase, M, I, L):
+            raise RuntimeError("Phase (-p), -M, L, and -I are mutually exclusive arguments")
+        if phase is not None:
+            self.command.append("-p")
+            self.command.append(str(phase))
+        elif M is not None:
+            self.command.append("-M")
+        elif I is not None:
+            self.command.append("-I")
+        elif L is not None:
+            self.command.append("-L")
+
+        if not mutually_exclusive(left_t, left_t):
+            raise RuntimeError("Transition bands options (-t or -n) are mutually exclusive")
+        if left_t is not None:
+            self.command.append("-t")
+            self.command.append(str(left_t))
+        if left_n is not None:
+            self.command.append("-n")
+            self.command.append(str(left_n))
+        
+        if hpfreq is not None and lpfreq is None:
+            self.command.append(str(hpfreq))
+        elif hpfreq is not None and lpfreq is not None:
+            self.command.append(str(hpfreq)+ "-" + str(lpfreq))
+        elif hpfreq is None and lpfreq is not None:
+            self.command.append(str(lpfreq))
+
+        if not mutually_exclusive(right_t, right_t):
+            raise RuntimeError("Transition bands options (-t or -n) are mutually exclusive")
+        if right_t is not None:
+            self.command.append("-t")
+            self.command.append(str(right_t))
+        if right_n is not None:
+            self.command.append("-n")
+            self.command.append(str(right_n))
 
     def bend(self, bends, frame_rate=None, over_sample=None):
         self.command.append("bend")
@@ -278,7 +330,7 @@ class AudioEffectsChain:
         if type in ["amplitude", "power", "dB"]:
             self.command.append(type)
         else:
-            raise InvalidEffectParameter("Type has to be dB, amplitude or power")
+            raise ValueError("Type has to be dB, amplitude or power")
         if limiter_gain is not None:
             self.command.append(str(limiter_gain))
         return self


### PR DESCRIPTION
I hope i didn't get too crazy on the inputs checking part on the sinc effect (tried to make it as clear as possible, since the original SoX doc is pretty confusing IMHO).

Also, I figured it'd be better to add a "custom" method to the effects chain, which would enable you to add your own effect string (pretty useful for effects that are not yet implemented). Since now all unimplemented effects can still be used, I think we sould remove all the "empty" methods in on the main object.