### PR TITLE
Implementation of compand effect

### DIFF
--- a/pysndfx/dsp.py
+++ b/pysndfx/dsp.py
@@ -74,8 +74,10 @@ class AudioEffectsChain:
         self.command.append('-n')
         return self
 
-    def compand(self, attack=0.05, decay=0.5):
-        raise NotImplemented()
+    def compand(self, attack=0.2, decay=1, soft_knee=2.0, threshold=-20, db_from=-20.0, db_to=-20.0):
+        self.command.append('compand')
+        self.command.append(str(attack) + ',' + str(decay))
+        self.command.append(str(soft_knee) + ':' + str(threshold) + ',' + str(db_from) + ',' + str(db_to))
         return self
 
     def sinc(self,


### PR DESCRIPTION
The goal of this PR is to add implementation of `compand` effect. Let me rephrase [SoX documentation ](https://linux.die.net/man/1/sox) to explain parameters:

> The transfer function (`soft_knee`:`threshold`,...') says that very soft sounds (below `threshold`dB) will remain unchanged. This will stop the compander from boosting the volume on 'silent' passages such as between movements. However, sounds in the range `db_from`dB to 0dB (maximum volume) will be boosted so that the `db_from`dB dynamic range of the original music will be compressed into a `db_to`dB range

The default parameters are actually _transparent_ for audio files, meaning the command not change the audio.