### PR TITLE
using local logger instead of root logger

### DIFF
--- a/pysndfx/dsp.py
+++ b/pysndfx/dsp.py
@@ -7,7 +7,7 @@ from subprocess import PIPE, Popen
 
 import numpy as np
 
-from .sndfiles import FilePathInput, FileBufferInput, NumpyArrayInput, FilePathOutput, NumpyArrayOutput, FileBufferOutput
+from .sndfiles import logger, FilePathInput, FileBufferInput, NumpyArrayInput, FilePathOutput, NumpyArrayOutput, FileBufferOutput
 
 
 def mutually_exclusive(*args):
@@ -123,7 +123,7 @@ class AudioEffectsChain:
         if left_n is not None:
             self.command.append("-n")
             self.command.append(str(left_n))
-        
+
         if high_pass_frequency is not None and low_pass_frequency is None:
             self.command.append(str(high_pass_frequency))
         elif high_pass_frequency is not None and low_pass_frequency is not None:
@@ -408,7 +408,7 @@ class AudioEffectsChain:
             ] + list(map(str, self.command))),
             posix=False)
 
-        logging.debug("Running command : %s" % cmd)
+        logger.debug("Running command : %s" % cmd)
         if isinstance(stdin, np.ndarray):
             stdout, stderr = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE).communicate(stdin.tobytes(order="F"))
         else:

--- a/pysndfx/sndfiles.py
+++ b/pysndfx/sndfiles.py
@@ -11,6 +11,7 @@ ENCODINGS_MAPPING = {np.int16: "s16",
 
 PIPE_CHAR = "-"
 
+logger = logging.getLogger("pysndfx")
 
 class SoxInput(object):
     pipe = "-"
@@ -24,7 +25,7 @@ class FilePathInput(SoxInput):
     def __init__(self, filepath):
         super(FilePathInput, self).__init__()
         info_cmd = 'sox --i -c ' + filepath
-        logging.debug("Running info command : %s" % info_cmd)
+        logger.debug("Running info command : %s" % info_cmd)
         stdout, stderr = Popen(shlex.split(info_cmd, posix=False),
                                stdout=PIPE,
                                stderr=PIPE).communicate()

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -4,7 +4,8 @@ import librosa as lr
 import logging
 from pysndfx.dsp import AudioEffectsChain
 
-logging.getLogger().setLevel(logging.DEBUG)
+logger = logging.getLogger("pysndfx")
+logger.setLevel(logging.DEBUG)
 
 apply_audio_effects = AudioEffectsChain()\
     .highshelf()\


### PR DESCRIPTION
Hi,

`pysndfx` package uses the module-scope `logging` root logger, which could interfere with the other loggers. Right after calling pysndfx's logging message, my log messages are duplicated. So I'd like to ask you to use local singleton logger named 'pysndfx' by using `logging.getLogger('pysndfx')`  instead of the root logger.

Thank you!
Jinserk